### PR TITLE
chore: bump `populate` to `v1.1.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.0-rc.1",
       "license": "MIT",
       "dependencies": {
-        "@fourlights/strapi-plugin-deep-populate": "^1.0.1",
+        "@fourlights/strapi-plugin-deep-populate": "^1.1.0",
         "@strapi/design-system": "^2.0.0-rc.14",
         "@strapi/icons": "^2.0.0-rc.14",
         "dlv": "^1.1.3",
@@ -49,7 +49,7 @@
         "yalc": "^1.0.0-pre.53"
       },
       "peerDependencies": {
-        "@fourlights/strapi-plugin-deep-populate": "^1.0.1",
+        "@fourlights/strapi-plugin-deep-populate": "^1.1.0",
         "@strapi/admin": "^5.6.0",
         "@strapi/content-manager": "^5.6.0",
         "@strapi/design-system": "^2.0.0-rc.14",
@@ -1201,9 +1201,9 @@
       }
     },
     "node_modules/@fourlights/strapi-plugin-deep-populate": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@fourlights/strapi-plugin-deep-populate/-/strapi-plugin-deep-populate-1.0.1.tgz",
-      "integrity": "sha512-CSFca4IS2D6k9KoYWwl5KAxhllIGUFmj6Hcb759wcjsVjEDUixiM7dt13ChC+8NwePy3Fgemg+6u7bJWl89apA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@fourlights/strapi-plugin-deep-populate/-/strapi-plugin-deep-populate-1.1.0.tgz",
+      "integrity": "sha512-JVB9zSmIHaVMoa16b5zoKMu9CNTNHEF5rzft4uOxXrSYPsj3LuNQ5v8AT665Nz0J+I031UTTB7mP1RUwVxQLfw==",
       "license": "MIT",
       "dependencies": {
         "dlv": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ci:server": "biome ci server"
   },
   "dependencies": {
-    "@fourlights/strapi-plugin-deep-populate": "^1.0.1",
+    "@fourlights/strapi-plugin-deep-populate": "^1.1.0",
     "@strapi/design-system": "^2.0.0-rc.14",
     "@strapi/icons": "^2.0.0-rc.14",
     "dlv": "^1.1.3",
@@ -83,7 +83,7 @@
     "yalc": "^1.0.0-pre.53"
   },
   "peerDependencies": {
-    "@fourlights/strapi-plugin-deep-populate": "^1.0.1",
+    "@fourlights/strapi-plugin-deep-populate": "^1.1.0",
     "@strapi/admin": "^5.6.0",
     "@strapi/content-manager": "^5.6.0",
     "@strapi/design-system": "^2.0.0-rc.14",


### PR DESCRIPTION
This should fix `media` attributes not being copied