### PR TITLE
chore(deps): update strapi-plugin-deep-populate to v1.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.1-rc.11",
       "license": "MIT",
       "dependencies": {
-        "@fourlights/strapi-plugin-deep-populate": "^1.6.0",
+        "@fourlights/strapi-plugin-deep-populate": "^1.9.0",
         "@strapi/design-system": "^2.0.0-rc.14",
         "@strapi/icons": "^2.0.0-rc.14",
         "dlv": "^1.1.3",
@@ -48,7 +48,7 @@
         "typescript": "^5.7.2"
       },
       "peerDependencies": {
-        "@fourlights/strapi-plugin-deep-populate": "^1.6.0",
+        "@fourlights/strapi-plugin-deep-populate": "^1.9.0",
         "@strapi/admin": "^5.6.0",
         "@strapi/content-manager": "^5.6.0",
         "@strapi/design-system": "^2.0.0-rc.14",
@@ -1200,9 +1200,9 @@
       }
     },
     "node_modules/@fourlights/strapi-plugin-deep-populate": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@fourlights/strapi-plugin-deep-populate/-/strapi-plugin-deep-populate-1.6.0.tgz",
-      "integrity": "sha512-42nGmFUO/ege9kggxz6y0oufNxoqohy9Ie3QCYeEXu53OWJ0NcIx6G65cw/gaO0uBZ0mKdBiDQLnlLUMzZ3n2g==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@fourlights/strapi-plugin-deep-populate/-/strapi-plugin-deep-populate-1.9.0.tgz",
+      "integrity": "sha512-rgXARechZczvjE2J/Mk1V9mJs95bml3Dyv/jzyOn/EmJtgnUyYP/+/lxWjBwyPMXM5qzQ5WCDYQNIE7M57vEVQ==",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "ci:server": "biome ci server"
   },
   "dependencies": {
-    "@fourlights/strapi-plugin-deep-populate": "^1.6.0",
+    "@fourlights/strapi-plugin-deep-populate": "^1.9.0",
     "@strapi/design-system": "^2.0.0-rc.14",
     "@strapi/icons": "^2.0.0-rc.14",
     "dlv": "^1.1.3",
@@ -83,7 +83,7 @@
     "typescript": "^5.7.2"
   },
   "peerDependencies": {
-    "@fourlights/strapi-plugin-deep-populate": "^1.6.0",
+    "@fourlights/strapi-plugin-deep-populate": "^1.9.0",
     "@strapi/admin": "^5.6.0",
     "@strapi/content-manager": "^5.6.0",
     "@strapi/design-system": "^2.0.0-rc.14",


### PR DESCRIPTION
Updates @fourlights/strapi-plugin-deep-populate from v1.6.0 to v1.9.0 in both dependencies and peerDependencies.